### PR TITLE
Load subr-x for using its macros and functions

### DIFF
--- a/counsel-org-capture-string.el
+++ b/counsel-org-capture-string.el
@@ -40,6 +40,7 @@
 (require 'map)
 (require 'imenu)
 (require 'cl-lib)
+(require 'subr-x)
 
 (defcustom counsel-org-capture-string-sources
   '(counsel-org-capture-string--org-clock-candidates


### PR DESCRIPTION
Fix following warnings

```
counsel-org-capture-string.el:122:49:Warning: ‘(help (cdr (assoc str
    counsel-org-capture-string--candidates)))’ is a malformed function
counsel-org-capture-string.el:125:35:Warning: reference to free variable
    ‘help’

In counsel-org-capture-string--projectile-candidates:
counsel-org-capture-string.el:215:8:Warning: ‘(project (and (featurep (quote
    projectile)) (bound-and-true-p projectile-cached-project-name)))’ is a
    malformed function
counsel-org-capture-string.el:217:15:Warning: reference to free variable
    ‘project’

In counsel-org-capture-string--imenu-candidates:
counsel-org-capture-string.el:221:8:Warning: ‘(filename (buffer-file-name))’
    is a malformed function
counsel-org-capture-string.el:227:46:Warning: reference to free variable
    ‘filename’
counsel-org-capture-string.el:237:22:Warning: ‘(x (cdr cell))’ is a malformed
    function
counsel-org-capture-string.el:243:64:Warning: reference to free variable ‘x’
counsel-org-capture-string.el:247:49:Warning: reference to free variable
    ‘marker’

In end of data:
counsel-org-capture-string.el:253:1:Warning: the following functions are not known to be defined: if-let,
    string-join, when-let, marker
```